### PR TITLE
Only submit coverage when on terrestris/geojson-walk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: node_js
 node_js:
     - 10
     - 12
-script: npm run ci
+script:
+    - npm run ci
+after_success:
+    - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm run lint && jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "ci": "npm run lint && npm run test:coverage && coveralls < coverage/lcov.info"
+    "ci": "npm run lint && npm run test:coverage",
+    "coveralls": "coveralls < coverage/lcov.info"
   },
   "author": "Marc Jansen <jansen@terrestris.de>",
   "license": "MIT",


### PR DESCRIPTION
This is a test, let's see if this removes failures when on a fork.